### PR TITLE
Using intval,floatval instead of anonymous functions

### DIFF
--- a/src/Db/DataTypeParsers/Basic.php
+++ b/src/Db/DataTypeParsers/Basic.php
@@ -23,15 +23,11 @@ class Basic implements Db\DataTypeParser
 				case '_int2':
 				case '_int4':
 				case '_int8':
-					return $this->parseArray($value, static function ($value): int {
-						return (int) $value;
-					});
+					return $this->parseArray($value, 'intval');
 				case '_float4':
 				case '_float8':
 				case '_numeric':
-					return $this->parseArray($value, static function ($value): float {
-						return (float) $value;
-					});
+					return $this->parseArray($value, 'floatval');
 				case '_bool':
 					return $this->parseArray($value, [$this, 'parseBool']);
 				case '_date':


### PR DESCRIPTION
I thinks it's more readable + times are better:
```php
<?php declare(strict_types=1);

$array = ['10', '20', '99', 5, 6, 8];

$s = microtime(true);

for ($i = 0; $i < 1000000; ++$i) {
	array_map('intval', $array);
}

var_dump(microtime(true) - $s);



$s = microtime(true);

for ($i = 0; $i < 1000000; ++$i) {
	array_map(static function ($value): int {
		return (int) $value;
	}, $array);
}

var_dump(microtime(true) - $s);
```

Times:
```
float(0.23932003974915)
float(0.40849304199219)
```