### PR TITLE
[Php8] Fix connection __sleep return type

### DIFF
--- a/src/Db/Connection.php
+++ b/src/Db/Connection.php
@@ -640,7 +640,7 @@ class Connection
 	/**
 	 * Prevents serialization.
 	 */
-	public function __sleep(): void
+	public function __sleep(): array
 	{
 		throw new \RuntimeException(\sprintf('You can\'t serialize or unserialize \'%s\' instances.', static::class));
 	}


### PR DESCRIPTION
Php8 requires `__sleep(): array` return type.  
https://www.php.net/manual/en/migration80.incompatible.php